### PR TITLE
Use the same base image for builder step

### DIFF
--- a/src/setuptools_docker/Dockerfile.j2
+++ b/src/setuptools_docker/Dockerfile.j2
@@ -1,4 +1,4 @@
-FROM python:3.8-bullseye AS builder
+FROM {{ base_image }} AS builder
 
 {% for package in builder_extra_os_packages %}
 {% if loop.first %}


### PR DESCRIPTION
If we are using complete different images, the packages will not match.